### PR TITLE
Updating peer deps for `react` and `react-dom`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     ]
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",


### PR DESCRIPTION
Updating `react` and `react-dom` to support 16, 17, and 18.