### PR TITLE
Enhance Popover with Arbitrary DOM Props Support

### DIFF
--- a/src/components/Popover/components/Popover/Popover.tsx
+++ b/src/components/Popover/components/Popover/Popover.tsx
@@ -70,6 +70,7 @@ const Popover: ForwardRefRenderFunction<HTMLElement, PopoverProps> = (
     width,
     height,
     usePortal,
+    ...rest
   },
   ref
 ) => {
@@ -186,6 +187,7 @@ const Popover: ForwardRefRenderFunction<HTMLElement, PopoverProps> = (
             height: useTriggerHeight ? triggerDimensions.height : height,
             ...containerStyle,
           }}
+          {...rest}
         >
           {withArrow && (
             <span
@@ -249,6 +251,7 @@ const Popover: ForwardRefRenderFunction<HTMLElement, PopoverProps> = (
               left: '-999px',
               top: '-999px',
             }}
+            {...rest}
           >
             <div
               className="idui-popover__content"

--- a/src/components/Popover/components/Popover/Popover.tsx
+++ b/src/components/Popover/components/Popover/Popover.tsx
@@ -70,7 +70,7 @@ const Popover: ForwardRefRenderFunction<HTMLElement, PopoverProps> = (
     width,
     height,
     usePortal,
-    ...rest
+    ...props
   },
   ref
 ) => {
@@ -187,7 +187,7 @@ const Popover: ForwardRefRenderFunction<HTMLElement, PopoverProps> = (
             height: useTriggerHeight ? triggerDimensions.height : height,
             ...containerStyle,
           }}
-          {...rest}
+          {...props}
         >
           {withArrow && (
             <span
@@ -251,7 +251,7 @@ const Popover: ForwardRefRenderFunction<HTMLElement, PopoverProps> = (
               left: '-999px',
               top: '-999px',
             }}
-            {...rest}
+            {...props}
           >
             <div
               className="idui-popover__content"

--- a/src/components/Popover/types.ts
+++ b/src/components/Popover/types.ts
@@ -1,4 +1,9 @@
-import { ReactChild, ReactEventHandler, ReactNode } from 'react';
+import {
+  ReactChild,
+  ReactEventHandler,
+  ReactNode,
+  HTMLAttributes,
+} from 'react';
 import { ArrowPlacement, PopoverTriggerType, PopoverPlacement } from './enums';
 
 export interface PopoverChildrenProps {
@@ -12,7 +17,7 @@ export interface PopoverContentProps {
   close: () => void;
 }
 
-export interface PopoverProps {
+export interface PopoverProps extends HTMLAttributes<HTMLElement> {
   /**
    * whether wait for trigger event to initialize popover or not
    * @default true


### PR DESCRIPTION
### Summary
This PR extends the `Popover` component to support **arbitrary HTML attributes** (e.g., `data-loc`, `data-testid`, `aria-label`, etc.) by:
- Extending `PopoverProps` with `React.HTMLAttributes<HTMLElement>`
- Destructuring and spreading `...props` props
- Applying them to **both** the visible popover container and the offscreen measurement portal

### Changes
- `types.ts`: `PopoverProps` now extends `React.HTMLAttributes<HTMLElement>`
- `Popover.tsx`:
  - Spread `...props` on:
    - Animated popover
    - Portal
- No behavioral changes; fully backward compatible

### Example Usage
```tsx
<Popover data-loc="status-popover" content="...">
  <button>Trigger</button>
</Popover>